### PR TITLE
Fix use of Clipboard

### DIFF
--- a/textadapter.py
+++ b/textadapter.py
@@ -426,7 +426,8 @@ class TextViewer(GObject.GObject):
         pass
 
     def copy(self):
-        self.textview.get_buffer().copy_clipboard(Gtk.Clipboard())
+        clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+        self.textview.get_buffer().copy_clipboard(clipboard)
 
     def _view_buttonrelease_event_cb(self, view, event):
         self._has_selection = \


### PR DESCRIPTION
We have to specify which Clipboard must be used, in this case,
it is Gdk.SELECTION_CLIPBOARD [1].

[1] https://developer.gnome.org/gtk3/3.8/gtk3-Clipboards.html

Signed-off-by: Martin Abente Lahaye <tch@sugarlabs.org>